### PR TITLE
Pipe script keywords and restful improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.0.12:
+* Adding assert keyword (#143)
+* Fixing new keyword for blank constructors (#142 )
+* Rest Transpiler:
+  * Handling multiple QueryString values (#139)
+  * Only passing ContentType to invoker if invoker supports it (#141)
+  * Defaulting to JSON body when ContentType is unspecified (#140)
+---
+
 ## 0.0.11:
 * Source Generators Now Support Parameters / Arguments (#75)
 * Invoke-PipeScript Terminating Build Errors (#135)

--- a/PipeScript.psd1
+++ b/PipeScript.psd1
@@ -1,22 +1,33 @@
 @{
-    ModuleVersion     = '0.0.11'
+    ModuleVersion     = '0.0.12'
     Description       = 'An Extensible Transpiler for PowerShell (and anything else)'
     RootModule        = 'PipeScript.psm1'
     PowerShellVersion = '4.0'
     AliasesToExport   = '*'
     FormatsToProcess  = 'PipeScript.format.ps1xml'
     TypesToProcess    = 'PipeScript.types.ps1xml'
-    Guid = 'fc054786-b1ce-4ed8-a90f-7cc9c27edb06'
-    CompanyName='Start-Automating'
-    Copyright='2022 Start-Automating'
-    Author='James Brundage'
+    Guid              = 'fc054786-b1ce-4ed8-a90f-7cc9c27edb06'
+    CompanyName       = 'Start-Automating'
+    Copyright         = '2022 Start-Automating'
+    Author            = 'James Brundage'
     PrivateData = @{
         PSData = @{
             ProjectURI = 'https://github.com/StartAutomating/PipeScript'
             LicenseURI = 'https://github.com/StartAutomating/PipeScript/blob/main/LICENSE'
-
-            Tags = 'PipeScript','PowerShell', 'Transpilation', 'Compiler'
+            RecommendModule = @('PSMinifier')
+            RelatedModule   = @()
+            BuildModule     = @('EZOut','Piecemeal','PipeScript','HelpOut', 'PSDevOps')
+            Tags            = 'PipeScript','PowerShell', 'Transpilation', 'Compiler'
             ReleaseNotes = @'
+## 0.0.12:
+* Adding assert keyword (#143)
+* Fixing new keyword for blank constructors (#142 )
+* Rest Transpiler:
+  * Handling multiple QueryString values (#139)
+  * Only passing ContentType to invoker if invoker supports it (#141)
+  * Defaulting to JSON body when ContentType is unspecified (#140)
+---
+
 ## 0.0.11:
 * Source Generators Now Support Parameters / Arguments (#75)
 * Invoke-PipeScript Terminating Build Errors (#135)

--- a/README.md
+++ b/README.md
@@ -4,11 +4,16 @@
 
 # What Is PipeScript?
 
-> PipeScript is a transpiled scripting language built atop of PowerShell.
+PipeScript is a scripting language built atop PowerShell.
 
-> PipeScript can be run interactively
 
-> PipeScript can embedded within many languages to dynamically generate source code
+PipeScript is transpiled into PowerShell.
+
+
+PipeScript can be run interactively, or used to build more PowerShell with less code.
+
+
+PipeScript can also be embedded in many other languages to dynamically generate source code.
 
 ## What's a Transpiler?
 

--- a/Transpilers/Keywords/New.psx.ps1
+++ b/Transpilers/Keywords/New.psx.ps1
@@ -20,6 +20,8 @@
 .EXAMPLE
     .> { new int[] 5 }
 .EXAMPLE
+    .> { new Timespan }
+.EXAMPLE
     .> { new datetime 12/31/1999 }
 .EXAMPLE
     .> { new @{RandomNumber = Get-Random; A ='b'}}

--- a/Transpilers/Keywords/New.psx.ps1
+++ b/Transpilers/Keywords/New.psx.ps1
@@ -97,7 +97,13 @@ process {
                 $constructorArguments[0] -is [string]) {
                 "[$newTypeName]::parse(" + ($constructorArguments -join ',') + ")"
             } elseif ($realNewType::new) {
-                "[$newTypeName]::new(" + ($constructorArguments -join ',') + ")"
+                if ($constructorArguments) {
+                    "[$newTypeName]::new(" + ($constructorArguments -join ',') + ")"
+                } elseif ($realNewType::new.overloadDefinitions -notmatch '\(\)$') {
+                    "[$newTypeName]::new(`$null)"
+                } else {
+                    "[$newTypeName]::new()"
+                }
             } elseif ($realNewType.IsPrimitive) {
                 if ($constructorArguments) {
                     if ($constructorArguments.Length -eq 1) {

--- a/Transpilers/Keywords/README.md
+++ b/Transpilers/Keywords/README.md
@@ -3,12 +3,53 @@ This directory and it's subdirectories contain additional language keywords with
 Most keywords will be implemented as a Transpiler that tranforms a CommandAST.
 
 
-|DisplayName       |Synopsis                    |
-|------------------|----------------------------|
-|[New](New.psx.ps1)|['new' keyword](New.psx.ps1)|
+|DisplayName             |Synopsis                        |
+|------------------------|--------------------------------|
+|[Assert](Assert.psx.ps1)|[Assert keyword](Assert.psx.ps1)|
+|[New](New.psx.ps1)      |['new' keyword](New.psx.ps1)    |
 
 
 
+
+## Assert Example 1
+
+
+~~~PowerShell
+    # With no second argument, assert will throw an error with the condition of the assertion.
+    Invoke-PipeScript {
+        assert (1 -eq 1)
+    } -Debug
+~~~
+
+## Assert Example 2
+
+
+~~~PowerShell
+    # With a second argument of a string, assert will throw an error
+    Invoke-PipeScript {
+        assert ($true) "It's true"
+    } -Debug
+~~~
+
+## Assert Example 3
+
+
+~~~PowerShell
+    # Conditions can also be written as a ScriptBlock
+    Invoke-PipeScript {
+        assert {$true} "Process id '$pid' Asserted"
+    } -Verbose
+~~~
+
+## Assert Example 4
+
+
+~~~PowerShell
+    # If the assertion action was a ScriptBlock, no exception is automatically thrown
+    Invoke-PipeScript {
+        assert ($true) { Write-Information "Assertion was true"}
+    } -Verbose
+~~~
 
 ## New Example 1
 
@@ -35,17 +76,24 @@ Most keywords will be implemented as a Transpiler that tranforms a CommandAST.
 
 
 ~~~PowerShell
-    .> { new datetime 12/31/1999 }
+    .> { new Timespan }
 ~~~
 
 ## New Example 5
 
 
 ~~~PowerShell
-    .> { new @{RandomNumber = Get-Random; A ='b'}}
+    .> { new datetime 12/31/1999 }
 ~~~
 
 ## New Example 6
+
+
+~~~PowerShell
+    .> { new @{RandomNumber = Get-Random; A ='b'}}
+~~~
+
+## New Example 7
 
 
 ~~~PowerShell

--- a/Transpilers/Rest.psx.ps1
+++ b/Transpilers/Rest.psx.ps1
@@ -430,7 +430,7 @@ process {
     if ($method) {
         $invokeSplat.Method = $method
     }
-    if ($ContentType) {
+    if ($ContentType -and $invokerCommandInfo.Parameters.ContentType) {        
         $invokeSplat.ContentType = $ContentType
     }
 }
@@ -520,7 +520,7 @@ process {
             @(foreach ($bodyPart in $completeBody.GetEnumerator()) {
                 "$($bodyPart.Key.ToString().ToLower())=$([Web.HttpUtility]::UrlEncode($bodyPart.Value))"
             }) -join '&'
-        } elseif ($ContentType -match 'json') {
+        } elseif ($ContentType -match 'json' -or -not $ContentType) {
             ConvertTo-Json $completeBody
         }
 

--- a/docs/Assert.md
+++ b/docs/Assert.md
@@ -1,0 +1,78 @@
+
+Assert
+------
+### Synopsis
+Assert keyword
+
+---
+### Description
+
+Assert is a common keyword in many programming languages.
+
+In PipeScript, Asset will take a condition and an optional action.
+
+The condtion may be contained in either parenthesis or a [ScriptBlock].
+
+If there is no action, the assertion will throw an exception containing the condition.
+
+If the action is a string, the assertion will throw that error as a string.
+
+If the action is a ScriptBlock, it will be run if the assertion is false.
+
+Assertions will not be transpiled or included if -Verbose or -Debug has not been set.
+
+Additionally, while running, Assertions will be ignored if -Verbose or -Debug has not been set.
+
+---
+### Examples
+#### EXAMPLE 1
+```PowerShell
+# With no second argument, assert will throw an error with the condition of the assertion.
+Invoke-PipeScript {
+    assert (1 -eq 1)
+} -Debug
+```
+
+#### EXAMPLE 2
+```PowerShell
+# With a second argument of a string, assert will throw an error
+Invoke-PipeScript {
+    assert ($true) "It's true"
+} -Debug
+```
+
+#### EXAMPLE 3
+```PowerShell
+# Conditions can also be written as a ScriptBlock
+Invoke-PipeScript {
+    assert {$true} "Process id '$pid' Asserted"
+} -Verbose
+```
+
+#### EXAMPLE 4
+```PowerShell
+# If the assertion action was a ScriptBlock, no exception is automatically thrown
+Invoke-PipeScript {
+    assert ($true) { Write-Information "Assertion was true"}
+} -Verbose
+```
+
+---
+### Parameters
+#### **CommandAst**
+
+The CommandAst
+
+
+
+|Type              |Requried|Postion|PipelineInput |
+|------------------|--------|-------|--------------|
+|```[CommandAst]```|true    |named  |true (ByValue)|
+---
+### Syntax
+```PowerShell
+Assert -CommandAst <CommandAst> [<CommonParameters>]
+```
+---
+
+

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.0.12:
+* Adding assert keyword (#143)
+* Fixing new keyword for blank constructors (#142 )
+* Rest Transpiler:
+  * Handling multiple QueryString values (#139)
+  * Only passing ContentType to invoker if invoker supports it (#141)
+  * Defaulting to JSON body when ContentType is unspecified (#140)
+---
+
 ## 0.0.11:
 * Source Generators Now Support Parameters / Arguments (#75)
 * Invoke-PipeScript Terminating Build Errors (#135)

--- a/docs/New.md
+++ b/docs/New.md
@@ -38,15 +38,20 @@ If 'new'
 
 #### EXAMPLE 4
 ```PowerShell
-{ new datetime 12/31/1999 }
+{ new Timespan }
 ```
 
 #### EXAMPLE 5
 ```PowerShell
-{ new @{RandomNumber = Get-Random; A ='b'}}
+{ new datetime 12/31/1999 }
 ```
 
 #### EXAMPLE 6
+```PowerShell
+{ new @{RandomNumber = Get-Random; A ='b'}}
+```
+
+#### EXAMPLE 7
 ```PowerShell
 { new Diagnostics.ProcessStartInfo @{FileName='f'} }
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,11 +4,16 @@
 
 # What Is PipeScript?
 
-> PipeScript is a transpiled scripting language built atop of PowerShell.
+PipeScript is a scripting language built atop PowerShell.
 
-> PipeScript can be run interactively
 
-> PipeScript can embedded within many languages to dynamically generate source code
+PipeScript is transpiled into PowerShell.
+
+
+PipeScript can be run interactively, or used to build more PowerShell with less code.
+
+
+PipeScript can also be embedded in many other languages to dynamically generate source code.
 
 ## What's a Transpiler?
 

--- a/docs/Rest.md
+++ b/docs/Rest.md
@@ -210,6 +210,17 @@ If a parameter is a [switch], it will be turned into a [bool].
 |----------------|--------|-------|-------------|
 |```[PSObject]```|false   |named  |false        |
 ---
+#### **JoinQueryValue**
+
+If provided, will join multiple values of a query by this string.
+If the string is '&', each value will be provided as a key-value pair.
+
+
+
+|Type          |Requried|Postion|PipelineInput|
+|--------------|--------|-------|-------------|
+|```[String]```|false   |named  |false        |
+---
 #### **ForEachOutput**
 
 A script block to be run on each output.
@@ -222,7 +233,7 @@ A script block to be run on each output.
 ---
 ### Syntax
 ```PowerShell
-Rest [-ScriptBlock <ScriptBlock>] [-RESTEndpoint] <String[]> [-ContentType <String>] [-Method <String>] [-InvokeCommand <String>] [-InvokeParameterVariable <String>] [-UriParameterHelp <IDictionary>] [-UriParameterType <IDictionary>] [-BodyParameter <PSObject>] [-QueryParameter <PSObject>] [-ForEachOutput <ScriptBlock>] [<CommonParameters>]
+Rest [-ScriptBlock <ScriptBlock>] [-RESTEndpoint] <String[]> [-ContentType <String>] [-Method <String>] [-InvokeCommand <String>] [-InvokeParameterVariable <String>] [-UriParameterHelp <IDictionary>] [-UriParameterType <IDictionary>] [-BodyParameter <PSObject>] [-QueryParameter <PSObject>] [-JoinQueryValue <String>] [-ForEachOutput <ScriptBlock>] [<CommonParameters>]
 ```
 ---
 


### PR DESCRIPTION
## 0.0.12:
* Adding assert keyword (#143)
* Fixing new keyword for blank constructors (#142 )
* Rest Transpiler:
  * Handling multiple QueryString values (#139)
  * Only passing ContentType to invoker if invoker supports it (#141)
  * Defaulting to JSON body when ContentType is unspecified (#140)